### PR TITLE
#13 feat : 프로필 조회, 프로필 수정, refresh 토큰 검증 관련 기능 추가

### DIFF
--- a/src/main/java/com/sparta/vicky/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/vicky/security/JwtAuthenticationFilter.java
@@ -3,13 +3,11 @@ package com.sparta.vicky.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.vicky.jwt.JwtProvider;
 import com.sparta.vicky.user.dto.LoginRequest;
-import com.sparta.vicky.user.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -24,9 +22,6 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final JwtProvider jwtProvider;
-
-    @Autowired
-    private UserService userService;
 
     public JwtAuthenticationFilter(JwtProvider jwtProvider) {
         this.jwtProvider = jwtProvider;
@@ -77,9 +72,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         res.addHeader(JwtProvider.AUTHORIZATION_ACCESS_HEADER, accessToken);
         res.addHeader(JwtProvider.AUTHORIZATION_REFRESH_HEADER, refreshToken);
-
-        // 사용자 개인 필드에 refreshToken 저장
-        userService.saveRefreshToken(refreshToken, userDetails.getUser().getId());
 
         log.info("로그인 성공 : {}", username);
 

--- a/src/main/java/com/sparta/vicky/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vicky/user/controller/UserController.java
@@ -2,9 +2,7 @@ package com.sparta.vicky.user.controller;
 
 import com.sparta.vicky.base.dto.CommonResponse;
 import com.sparta.vicky.security.UserDetailsImpl;
-import com.sparta.vicky.user.dto.SignupRequest;
-import com.sparta.vicky.user.dto.SignupResponse;
-import com.sparta.vicky.user.dto.WithdrawRequest;
+import com.sparta.vicky.user.dto.*;
 import com.sparta.vicky.user.entity.User;
 import com.sparta.vicky.user.service.UserService;
 import jakarta.validation.Valid;
@@ -12,16 +10,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.sparta.vicky.util.ControllerUtil.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api")
 public class UserController {
 
     private final UserService userService;
@@ -29,7 +24,7 @@ public class UserController {
     /**
      * 회원 가입
      */
-    @PostMapping("/signup")
+    @PostMapping("/user/signup")
     public ResponseEntity<CommonResponse<?>> signup(
             @Valid @RequestBody SignupRequest request,
             BindingResult bindingResult
@@ -51,7 +46,7 @@ public class UserController {
     /**
      * 회원 탈퇴
      */
-    @PostMapping("/withdraw")
+    @PostMapping("/user/withdraw")
     public ResponseEntity<CommonResponse<?>> withdraw(
             @RequestBody WithdrawRequest request,
             @AuthenticationPrincipal UserDetailsImpl userDetails
@@ -60,6 +55,54 @@ public class UserController {
             Long response = userService.withdraw(request, userDetails.getUser().getId());
 
             return getResponseEntity(response, "회원 탈퇴 성공");
+
+        } catch (Exception e) {
+            return getBadRequestResponseEntity(e);
+        }
+    }
+
+    /**
+     * 로그아웃
+     */
+    @PatchMapping("/user/logout")
+    public ResponseEntity<CommonResponse<?>> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            Long response = userService.logout(userDetails.getUser().getId());
+
+            return getResponseEntity(response, "로그아웃 성공");
+
+        } catch (Exception e) {
+            return getBadRequestResponseEntity(e);
+        }
+    }
+
+    /**
+     * 프로필 조회
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<CommonResponse<?>> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        try {
+            ProfileResponse response = userService.getProfile(userDetails.getUser().getId());
+
+            return getResponseEntity(response, "프로필 조회 성공");
+
+        } catch (Exception e) {
+            return getBadRequestResponseEntity(e);
+        }
+    }
+
+    /**
+     * 프로필 수정
+     */
+    @PatchMapping("/profile")
+    public ResponseEntity<CommonResponse<?>> updateProfile(
+            @Valid @RequestBody UpdateProfileRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        try {
+            ProfileResponse response = userService.updateProfile(request, userDetails.getUser().getId());
+
+            return getResponseEntity(response, "프로필 수정 성공");
 
         } catch (Exception e) {
             return getBadRequestResponseEntity(e);

--- a/src/main/java/com/sparta/vicky/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vicky/user/controller/UserController.java
@@ -109,4 +109,22 @@ public class UserController {
         }
     }
 
+    /**
+     * 비밀번호 수정
+     */
+    @PatchMapping("/profile")
+    public ResponseEntity<CommonResponse<?>> updateProfile(
+            @Valid @RequestBody UpdatePassword request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        try {
+            ProfileResponse response = userService.updatePassword(request, userDetails.getUser().getId());
+
+            return getResponseEntity(response, "비밀번호 수정 성공");
+
+        } catch (Exception e) {
+            return getBadRequestResponseEntity(e);
+        }
+    }
+
 }

--- a/src/main/java/com/sparta/vicky/user/dto/ProfileResponse.java
+++ b/src/main/java/com/sparta/vicky/user/dto/ProfileResponse.java
@@ -5,13 +5,11 @@ import lombok.Data;
 @Data
 public class ProfileResponse {
 
-    private String username;
     private String name;
     private String email;
     private String introduce;
 
-    public ProfileResponse(String username, String name, String email, String introduce) {
-        this.username = username;
+    public ProfileResponse(String name, String email, String introduce) {
         this.name = name;
         this.email = email;
         this.introduce = introduce;

--- a/src/main/java/com/sparta/vicky/user/dto/ProfileResponse.java
+++ b/src/main/java/com/sparta/vicky/user/dto/ProfileResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.vicky.user.dto;
+
+import lombok.Data;
+
+@Data
+public class ProfileResponse {
+
+    private String username;
+    private String name;
+    private String email;
+    private String introduce;
+
+    public ProfileResponse(String username, String name, String email, String introduce) {
+        this.username = username;
+        this.name = name;
+        this.email = email;
+        this.introduce = introduce;
+    }
+
+}

--- a/src/main/java/com/sparta/vicky/user/dto/SignupRequest.java
+++ b/src/main/java/com/sparta/vicky/user/dto/SignupRequest.java
@@ -19,10 +19,10 @@ public class SignupRequest {
             message = "비밀번호는 최소 10자 이상이어야 하며, 영문 대소문자, 숫자, 특수문자를 최소 1글자씩 포함해야 합니다.")
     private String password;
 
-    @NotBlank
+    @NotBlank(message = "이름을 입력해주세요.")
     private String name;
 
-    @NotBlank
+    @NotBlank(message = "이메일을 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
             message = "email 형식이 맞지 않습니다.")
     private String email;

--- a/src/main/java/com/sparta/vicky/user/dto/UpdatePassword.java
+++ b/src/main/java/com/sparta/vicky/user/dto/UpdatePassword.java
@@ -1,0 +1,19 @@
+package com.sparta.vicky.user.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+@Getter
+public class UpdatePassword {
+
+    @NotBlank(message = "현재 사용 중인 비밀번호를 입력하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{10,}$",
+            message = "비밀번호는 최소 10자 이상이어야 하며, 영문 대소문자, 숫자, 특수문자를 최소 1글자씩 포함해야 합니다.")
+    private String oldPassword;
+
+    @NotBlank(message = "변경할 비밀번호를 입력하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{10,}$",
+            message = "비밀번호는 최소 10자 이상이어야 하며, 영문 대소문자, 숫자, 특수문자를 최소 1글자씩 포함해야 합니다.")
+    private String newPassword;
+
+}

--- a/src/main/java/com/sparta/vicky/user/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/sparta/vicky/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,20 @@
+package com.sparta.vicky.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UpdateProfileRequest {
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+            message = "email 형식이 맞지 않습니다.")
+    private String email;
+
+    private String introduce;
+
+}

--- a/src/main/java/com/sparta/vicky/user/entity/User.java
+++ b/src/main/java/com/sparta/vicky/user/entity/User.java
@@ -89,4 +89,14 @@ public class User extends Timestamped {
         System.out.println("statusUpdatedAt = " + statusUpdatedAt);
     }
 
+    /**
+     * 프로필 수정 메서드
+     */
+    public void updateProfile(String name, String email, String introduce) {
+        this.name = name;
+        this.email = email;
+        this.introduce = introduce;
+        System.out.println("User.updateProfile");
+    }
+
 }

--- a/src/main/java/com/sparta/vicky/user/entity/User.java
+++ b/src/main/java/com/sparta/vicky/user/entity/User.java
@@ -99,4 +99,11 @@ public class User extends Timestamped {
         System.out.println("User.updateProfile");
     }
 
+    /**
+     * 비밀번호 수정
+     */
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/sparta/vicky/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/vicky/user/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
+    Optional<User> findByUsernameAndRefreshToken(String username, String refreshToken);
 }

--- a/src/main/java/com/sparta/vicky/user/service/UserService.java
+++ b/src/main/java/com/sparta/vicky/user/service/UserService.java
@@ -1,9 +1,6 @@
 package com.sparta.vicky.user.service;
 
-import com.sparta.vicky.user.dto.ProfileResponse;
-import com.sparta.vicky.user.dto.SignupRequest;
-import com.sparta.vicky.user.dto.UpdateProfileRequest;
-import com.sparta.vicky.user.dto.WithdrawRequest;
+import com.sparta.vicky.user.dto.*;
 import com.sparta.vicky.user.entity.User;
 import com.sparta.vicky.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -74,7 +71,7 @@ public class UserService {
      */
     public ProfileResponse getProfile(Long id) {
         User user = getUser(id);
-        return new ProfileResponse(user.getUsername(), user.getName(), user.getEmail(), user.getIntroduce());
+        return new ProfileResponse(user.getName(), user.getEmail(), user.getIntroduce());
     }
 
     /**
@@ -85,7 +82,23 @@ public class UserService {
         User user = getUser(id);
         user.updateProfile(request.getName(), request.getEmail(), request.getIntroduce());
 
-        return new ProfileResponse(user.getUsername(), user.getName(), user.getEmail(), user.getIntroduce());
+        return new ProfileResponse(user.getName(), user.getEmail(), user.getIntroduce());
+    }
+
+    /**
+     * 비밀번호 수정
+     */
+    @Transactional
+    public ProfileResponse updatePassword(UpdatePassword request, Long id) {
+        User user = getUser(id);
+
+        if(!passwordEncoder.matches(request.getOldPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        user.updatePassword(request.getNewPassword());
+
+        return new ProfileResponse(user.getName(), user.getEmail(), user.getIntroduce());
     }
 
     /**
@@ -107,4 +120,5 @@ public class UserService {
         return user.isPresent();
 
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 로그아웃/회원탈퇴/프로필조회/프로필 수정/refresh토큰 검증 기능 추가

## 📝작업 내용

> Controller 작성
> Service 작성
> Dto 생성 및 작성
> refresh 토큰 검증 기능 추가

## 💬리뷰 요구사항(선택)

> refresh토큰 검증하는 api를 만들지 않고 JwtAuthorizationFilter 토큰 검증 부분에서 해결했습니다 확인부탁드립니다.
> JwtAuthenticationFilter 에서 Jwt토큰을 userService를 주입받아 실행하는 부분을 jwtProvider에서 해결하도록 했습니다.(createRefreshToken메서드 내부) 이유 : 필터에서 userService를 주입받지 않도록하기위해서 + 토큰 생성 시 자동으로 user에 넣어주도록 
피드백 꼭!!!! 부탁드립니다.